### PR TITLE
add beefy type to exported package

### DIFF
--- a/exported/client.go
+++ b/exported/client.go
@@ -1,0 +1,4 @@
+package exported
+
+// Beefy is used to indicate the beefy light client.
+const Beefy = "11-beefy"

--- a/types/beefy.go
+++ b/types/beefy.go
@@ -1,8 +1,5 @@
 package types
 
-// Beefy is used to indicate the beefy light client.
-const Beefy = "11-beefy"
-
 type SizedByte32 [32]byte
 
 func (b *SizedByte32) Marshal() ([]byte, error) {

--- a/types/consensus_state.go
+++ b/types/consensus_state.go
@@ -3,20 +3,21 @@ package types
 import (
 	types1 "github.com/cosmos/ibc-go/v5/modules/core/23-commitment/types"
 
+	"github.com/ComposableFi/ics11-beefy/exported"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	clienttypes "github.com/cosmos/ibc-go/v5/modules/core/02-client/types"
-	"github.com/cosmos/ibc-go/v5/modules/core/exported"
+	ibcexported "github.com/cosmos/ibc-go/v5/modules/core/exported"
 )
 
-var _ exported.ConsensusState = (*ConsensusState)(nil)
+var _ ibcexported.ConsensusState = (*ConsensusState)(nil)
 
 // ClientType returns Beefy
 func (ConsensusState) ClientType() string {
-	return Beefy
+	return exported.Beefy
 }
 
 // GetRoot returns the commitment Root for the specific
-func (cs ConsensusState) GetRoot() exported.Root {
+func (cs ConsensusState) GetRoot() ibcexported.Root {
 	return types1.MerkleRoot{Hash: cs.Root}
 }
 
@@ -31,7 +32,7 @@ func (cs ConsensusState) ValidateBasic() error {
 		return sdkerrors.Wrap(clienttypes.ErrInvalidConsensus, "root cannot be empty")
 	}
 
-	if cs.Timestamp.Unix() <= 0 {
+	if cs.GetTimestamp() <= 0 {
 		return sdkerrors.Wrap(clienttypes.ErrInvalidConsensus, "timestamp must be a positive Unix time")
 	}
 	return nil

--- a/types/header.go
+++ b/types/header.go
@@ -4,18 +4,19 @@ import (
 	"bytes"
 	"encoding/binary"
 	"fmt"
+	ibcexported "github.com/cosmos/ibc-go/v5/modules/core/exported"
 	"log"
 	"time"
 
 	"github.com/ChainSafe/gossamer/lib/trie"
 	"github.com/ComposableFi/go-substrate-rpc-client/v4/scale"
 	rpcclienttypes "github.com/ComposableFi/go-substrate-rpc-client/v4/types"
+	"github.com/ComposableFi/ics11-beefy/exported"
 	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
 	ics02 "github.com/cosmos/ibc-go/v5/modules/core/02-client/types"
-	"github.com/cosmos/ibc-go/v5/modules/core/exported"
 )
 
-var _ exported.Header = &Header{}
+var _ ibcexported.Header = &Header{}
 
 const revisionNumber = 0
 
@@ -75,13 +76,13 @@ func (h Header) ConsensusState() *ConsensusState {
 
 // ClientType defines that the Header is a Beefy consensus algorithm
 func (h Header) ClientType() string {
-	return Beefy
+	return exported.Beefy
 }
 
 // GetHeight returns the current height. It returns 0 if the tendermint
 // header is nil.
 // NOTE: the header.Header is checked to be non nil in ValidateBasic.
-func (h Header) GetHeight() exported.Height {
+func (h Header) GetHeight() ibcexported.Height {
 	parachainHeader, err := DecodeParachainHeader(h.HeadersWithProof.Headers[0].ParachainHeader)
 	if err != nil {
 		log.Fatal(err)

--- a/types/misbehaviour.go
+++ b/types/misbehaviour.go
@@ -3,12 +3,13 @@ package types
 import (
 	"time"
 
+	"github.com/ComposableFi/ics11-beefy/exported"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	clienttypes "github.com/cosmos/ibc-go/v5/modules/core/02-client/types"
-	"github.com/cosmos/ibc-go/v5/modules/core/exported"
+	ibcexported "github.com/cosmos/ibc-go/v5/modules/core/exported"
 )
 
-var _ exported.Header = &Misbehaviour{}
+var _ ibcexported.Header = &Misbehaviour{}
 
 // FrozenHeight Use the same FrozenHeight for all misbehaviour
 var FrozenHeight = clienttypes.NewHeight(0, 1)
@@ -25,7 +26,7 @@ func NewMisbehaviour(clientID string, header1, header2 *Header) *Misbehaviour {
 
 // ClientType is Tendermint light client
 func (misbehaviour Misbehaviour) ClientType() string {
-	return Beefy
+	return exported.Beefy
 }
 
 // GetTime returns the timestamp at which misbehaviour occurred. It uses the
@@ -126,6 +127,6 @@ func (misbehaviour Misbehaviour) ValidateBasic() error {
 
 // GetHeight implements the current exported.Header interface, to be updated
 // TODO: Remove GetHeight()
-func (misbehaviour Misbehaviour) GetHeight() exported.Height {
+func (misbehaviour Misbehaviour) GetHeight() ibcexported.Height {
 	panic("implement me")
 }


### PR DESCRIPTION
adding beefy to the exported directory allows ibc-go to import the type and register it in its list of allowed clients without an import cycle